### PR TITLE
Fix filter items clip and shift

### DIFF
--- a/components/Filter/Filter.module.css
+++ b/components/Filter/Filter.module.css
@@ -86,7 +86,7 @@
     font-family: inherit;
     font-weight: 400;
     line-height: 1.1;
-    padding: .5em 0;
+    padding: .5em 1em .5em 0;
     cursor: pointer;
     transition: all .15s ease;
     transform-origin: 5% 50%;
@@ -96,9 +96,9 @@
     transform: scale(1.1);
 }
 
-
 .filteritem:last-child {
     margin-bottom: 0;
+    transform-origin: 0% 100%;
 }
 
 .filteritem__input {


### PR DESCRIPTION
- [x] Added a safe padding to the right of the item
- [x] Prevent shift of bottom item by `transform-origin`